### PR TITLE
Add AQ Kids resilience quiz to Education section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,8 +47,8 @@ Welcome to the Parenting Resources Awesome List! Discover a curated collection o
 ### Resilience & Social-Emotional Learning
 - [AQ Kids — Resilience Quiz](https://ordinarymantrying.com/tools/aq-kids/) - Free quiz that helps parents assess their child's resilience (AQ). Generates a personalized PDF report with a parent's letter. No sign-up needed.
 
-### Resilience & Social-Emotional Learning
-- [AQ Kids — Resilience Quiz](https://ordinarymantrying.com/tools/aq-kids/) - Free quiz that helps parents assess their child's resilience (AQ). Generates a personalized PDF report with a letter from the parent. No sign-up needed.
+### Family Planning & Organization
+- [Family Trip Planner](https://ordinarymantrying.com/tools/family-schedule.html) - Free browser-based itinerary planner for family trips. Add members, build day-by-day schedules with time slots and photos, then save as image or print. No login, no data stored — everything stays in your browser.
 
 ## Courses for Parents
 

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,12 @@ Welcome to the Parenting Resources Awesome List! Discover a curated collection o
 ### Educational Games
 - [Awsome Educational Games](https://github.com/yrgo/awesome-educational-games#readme) - Awesome list of educational games.
 
+### Resilience & Social-Emotional Learning
+- [AQ Kids — Resilience Quiz](https://ordinarymantrying.com/tools/aq-kids/) - Free quiz that helps parents assess their child's resilience (AQ). Generates a personalized PDF report with a parent's letter. No sign-up needed.
+
+### Resilience & Social-Emotional Learning
+- [AQ Kids — Resilience Quiz](https://ordinarymantrying.com/tools/aq-kids/) - Free quiz that helps parents assess their child's resilience (AQ). Generates a personalized PDF report with a letter from the parent. No sign-up needed.
+
 ## Courses for Parents
 
 - [Advanced Parenting Skills](https://alison.com/course/advanced-parenting-skills) - Free Course on developing mentoring mindsets.


### PR DESCRIPTION
## What

Adding **[AQ Kids — Resilience Quiz](https://ordinarymantrying.com/tools/aq-kids/)** to the Education → Resilience & Social-Emotional Learning section.

## About the tool

- Free browser-based quiz that helps parents assess their child's Adversity Quotient (AQ / resilience)
- Takes ~5 minutes, no app install, no sign-up
- Generates a personalized PDF report with a parent's letter to the child
- Research-backed questions across 5 resilience dimensions
- Available in English, works for ages 6–16

## Why it fits

This list covers parenting tools and resources. AQ Kids directly helps parents understand their child's emotional resilience — a topic increasingly important for modern parents.